### PR TITLE
Convert datetime object to a valid filename string without colon separators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ build/
 
 # Environments
 .env
+.vscode/
 
 # Package specific
 psi*.json

--- a/src/pyspeedinsights/api/response.py
+++ b/src/pyspeedinsights/api/response.py
@@ -115,6 +115,7 @@ def _get_timestamp(json_resp):
     """
 
     timestamp = json_resp["analysisUTCTimestamp"]
-    date = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
+    dt_object = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
+    date = dt_object.strftime("%Y-%m-%d_%H.%M.%S")
 
     return date


### PR DESCRIPTION
# Description

The timestamp strings generated for report filenames were previously `datetime` objects whose string representations were output as colon separators for the time substring by default. This caused issues with invalid filenames on Windows.

To fix this, I added an additional step to convert the `datetime` object to a string with `datetime.strftime()` using valid characters as separators. The chosen convention is `%Y-%m-%d_%H.%M.%S` for readability, where dates are separated by `-`, an `_` separates the date and time substrings, and times are separated by a `.`.

Fixes #4 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
